### PR TITLE
feat: Auto-fill author fields based on type

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -227,11 +227,22 @@ document.addEventListener('DOMContentLoaded', () => {
     headlineInput.addEventListener('input', updateOverallOutput);
     descriptionTextarea.addEventListener('input', updateOverallOutput);
     imageInput.addEventListener('input', updateOverallOutput);
-    authorTypeInput.addEventListener('input', updateOverallOutput);
     authorNameInput.addEventListener('input', updateOverallOutput);
     authorUrlInput.addEventListener('input', updateOverallOutput);
     datePublishedInput.addEventListener('input', updateOverallOutput);
     timePublishedInput.addEventListener('input', updateOverallOutput);
+
+    // Управляем полями автора в зависимости от выбора типа
+    authorTypeInput.addEventListener('change', () => {
+        if (authorTypeInput.value === 'Organization') {
+            authorNameInput.value = "Hello World";
+            authorUrlInput.value = "https://hwschool.online/";
+        } else if (authorTypeInput.value === 'Person') {
+            authorNameInput.value = '';
+            authorUrlInput.value = '';
+        }
+        updateOverallOutput(); // Обновляем JSON-LD после изменения
+    });
 
     // Слушатель для кнопки генерации BreadcrumbList
     generateBreadcrumbBtn.addEventListener('click', async () => {


### PR DESCRIPTION
Adds a change event listener to the #authorType select element.

- When 'Organization' is selected, the #authorName and #authorUrl fields are automatically populated with 'Hello World' and 'https://hwschool.online/'.
- When 'Person' is selected, the #authorName and #authorUrl fields are cleared.

The JSON-LD output is updated automatically after these changes.