### PR TITLE
feat: Extract publish date and set default time

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -19,10 +19,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Устанавливаем текущую дату и время по умолчанию при загрузке страницы
     const now = new Date();
     const today = now.toISOString().split('T')[0]; // YYYY-MM-DD
-    const currentTime = now.toTimeString().split(' ')[0].substring(0, 5); // HH:MM
-
     datePublishedInput.value = today;
-    timePublishedInput.value = currentTime;
+    timePublishedInput.value = '08:00'; // Устанавливаем время по умолчанию 08:00
 
     authorNameInput.value = "Hello World";
     authorUrlInput.value = "https://hwschool.online/";
@@ -188,6 +186,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
             const metaDescription = doc.querySelector('meta[name="description"]');
             descriptionTextarea.value = metaDescription ? metaDescription.getAttribute('content').trim() : '';
+
+            // --- Логика определения даты публикации ---
+            const dateElement = doc.querySelector('span.date-text.date-icon-calendar');
+            if (dateElement) {
+                const dateText = dateElement.textContent.trim(); // e.g., "14.08.2024"
+                const parts = dateText.split('.');
+                if (parts.length === 3) {
+                    const [day, month, year] = parts;
+                    // Преобразуем формат ДД.ММ.ГГГГ в ГГГГ-ММ-ДД для input[type="date"]
+                    datePublishedInput.value = `${year}-${month}-${day}`;
+                }
+            }
+            // Если элемент не найден, дата останется сегодняшней (установлена по умолчанию).
 
             // --- Логика определения автора ---
             const authorBlock = doc.querySelector('.t531');


### PR DESCRIPTION
This commit introduces two new features to streamline form filling:

1.  **Automatic Date Extraction:** The script now parses the fetched URL's content to find a `span` with classes `.date-text.date-icon-calendar`. If found, its text content (in `DD.MM.YYYY` format) is converted to `YYYY-MM-DD` and set as the value for the `#datePublished` field.
2.  **Default Time Change:** The default value for the `#timePublished` input field has been changed from the current time to a fixed `08:00`.