### PR TITLE
feat: Set default URL for Person author type

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -207,7 +207,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 authorTypeInput.value = 'Person';
                 const authorNameElement = authorBlock.querySelector('.t531__title');
                 authorNameInput.value = authorNameElement ? authorNameElement.textContent.trim() : '';
-                authorUrlInput.value = ''; // Очищаем URL для Person
+                authorUrlInput.value = 'https://hwschool.online/'; // Устанавливаем URL для Person
             } else {
                 // Блок не найден, устанавливаем автора как Organization
                 authorTypeInput.value = 'Organization';
@@ -262,10 +262,10 @@ document.addEventListener('DOMContentLoaded', () => {
             authorNameInput.value = "Hello World";
             authorUrlInput.value = "https://hwschool.online/";
         } else if (authorTypeInput.value === 'Person') {
-            // При ручном выборе "Person" просто очищаем поля,
-            // т.к. имя нужно вводить вручную, если оно не было определено автоматически.
+            // При ручном выборе "Person" очищаем имя для ручного ввода,
+            // а URL устанавливаем по умолчанию.
             authorNameInput.value = '';
-            authorUrlInput.value = '';
+            authorUrlInput.value = 'https://hwschool.online/';
         }
         updateOverallOutput(); // Обновляем JSON-LD после изменения
     });


### PR DESCRIPTION
Updates the logic to ensure that authors of type 'Person' are always assigned the URL 'https://hwschool.online/'.

- The automatic author detection logic now sets this URL when a 'Person' author is found on the page.
- The manual selection logic in the dropdown event listener also sets this URL when 'Person' is chosen, while still clearing the name field for manual input.